### PR TITLE
Leaderstat functionality and new check to canDamage 🙂

### DIFF
--- a/Sword/Config.lua
+++ b/Sword/Config.lua
@@ -8,7 +8,7 @@ return {
 	ForceTie = false; -- Force tie (allows sword to still do damage after a player dies)
 	DamageNPCs = true; -- Allows the sword to damage non-players
 	ForceFieldDamage = false; -- Ability to damage while having a forcefield
-	Leaderstat = "ENTER NAME HERE"; -- Name of the leaderstat to increase upon killing ("OFF" if you dont have any)   
+	HealAmount = 25; -- Amount of HP given after a kill (0 If you want heals off)
 	Float = false; -- Sword lunge float
 	TourneyMode = false; -- Tourney only functionality, this will break the sword outside of the tourney place!
 	Grips = {

--- a/Sword/Config.lua
+++ b/Sword/Config.lua
@@ -8,6 +8,7 @@ return {
 	ForceTie = false; -- Force tie (allows sword to still do damage after a player dies)
 	DamageNPCs = true; -- Allows the sword to damage non-players
 	ForceFieldDamage = false; -- Ability to damage while having a forcefield
+	Leaderstat = "ENTER LEADERSTAT HERE"; -- Name of the leaderstat to increase upon killing ("OFF" if you don't have any)  
 	Float = false; -- Sword lunge float
 	TourneyMode = false; -- Tourney only functionality, this will break the sword outside of the tourney place!
 	Grips = {

--- a/Sword/Config.lua
+++ b/Sword/Config.lua
@@ -8,7 +8,7 @@ return {
 	ForceTie = false; -- Force tie (allows sword to still do damage after a player dies)
 	DamageNPCs = true; -- Allows the sword to damage non-players
 	ForceFieldDamage = false; -- Ability to damage while having a forcefield
-	Leaderstat = "ENTER LEADERSTAT HERE"; -- Name of the leaderstat to increase upon killing ("OFF" if you don't have any)  
+	Leaderstat = "ENTER LEADERSTAT HERE"; -- Name of the leaderstat to increase upon killing ("OFF" if you dont have any)   
 	Float = false; -- Sword lunge float
 	TourneyMode = false; -- Tourney only functionality, this will break the sword outside of the tourney place!
 	Grips = {

--- a/Sword/Config.lua
+++ b/Sword/Config.lua
@@ -8,7 +8,7 @@ return {
 	ForceTie = false; -- Force tie (allows sword to still do damage after a player dies)
 	DamageNPCs = true; -- Allows the sword to damage non-players
 	ForceFieldDamage = false; -- Ability to damage while having a forcefield
-	Leaderstat = "ENTER LEADERSTAT HERE"; -- Name of the leaderstat to increase upon killing ("OFF" if you dont have any)   
+	Leaderstat = "ENTER NAME HERE"; -- Name of the leaderstat to increase upon killing ("OFF" if you dont have any)   
 	Float = false; -- Sword lunge float
 	TourneyMode = false; -- Tourney only functionality, this will break the sword outside of the tourney place!
 	Grips = {

--- a/Sword/SwordScript.server.lua
+++ b/Sword/SwordScript.server.lua
@@ -1,4 +1,3 @@
----@diagnostic disable: unused-function
 --[[
 	stfo tourney swords
 	written by StrangeEggs

--- a/Sword/SwordScript.server.lua
+++ b/Sword/SwordScript.server.lua
@@ -13,7 +13,7 @@ local tool = script.Parent
 local handle = tool.Handle
 local config = require(tool.Config)
 local damage = config.Damage.Idle
-local statName = config.Leaderstat
+local healAmount = config.HealAmount
 
 local sounds = {
 	Slash = handle.Slash;
@@ -116,19 +116,10 @@ end
 local function takeDamage(wielder: Player, humanoid: Humanoid, damage: IntValue)
 	humanoid:TakeDamage(damage)
 
-	-- Check if the wielder and statName are valid
-	if humanoid.Health <= 0 and statName and statName ~= "OFF" and wielder then
-		local folder = wielder:FindFirstChild("leaderstats") 
-		if folder then
-			local stat = folder:FindFirstChild(statName)
-			if stat then
-				stat.Value = stat.Value + 1
-			else
-				error("Couldn't add leaderstat to " .. wielder.Name .. " - Did you forget to change the leaderstat name?")
-			end
-		else
-			warn("Leaderstats folder not found - Make sure you have leaderstats built into your game!")
-		end
+	-- Heal the player
+	if humanoid.Health <= 0 and wielder and healAmount > 0 then
+		local currentHealth = wielder.Character.Humanoid.Health
+		wielder.Character.Humanoid.Health = math.min(currentHealth + healAmount, 100)
 	end
 end
 
@@ -143,7 +134,6 @@ local function blow(hit)
 	if not config.ForceFieldDamage and character:FindFirstChildOfClass("ForceField") then
 		return
 	end
-
 	if humanoid and humanoid ~= character.Humanoid and canDamage(hit) then
 		untagHumanoid(humanoid)
 		tagHumanoid(humanoid, wielder, hit)


### PR DESCRIPTION
- Added leaderstat functionality, easy to disable in config file and easy to change which leaderstat to add
-  Added `takeDamage()` which takes in the humanoid and the damage IntValue as parameters
- Added a check that evaluates if the victim is already dead, without the check it would fire `takeDamage()` despite the  victim being dead

**Let me know there are any issues or problems, just doing this to learn/for fun**